### PR TITLE
Fixed Command Injection in node-key-sender

### DIFF
--- a/key-sender.js
+++ b/key-sender.js
@@ -1,4 +1,4 @@
-var exec = require('child_process').exec;
+var exec = require('child_process').execFile;
 var path = require("path");
 
 module.exports = function() {
@@ -112,9 +112,9 @@ module.exports = function() {
         return new Promise(function(resolve, reject) {
             var jarPath = path.join(__dirname, 'jar', 'key-sender.jar');
 
-            var command = 'java -jar \"' + jarPath + '\" ' + arrParams.join(' ') + module.getCommandLineOptions();
+            var command = ['-jar', jarPath, arrParams.join(' '), module.getCommandLineOptions()];
 
-            return exec(command, {}, function(error, stdout, stderr) {
+            return exec('java', command, {}, function(error, stdout, stderr) {
                 if (error == null) {
                     resolve(stdout, stderr);
                 } else {


### PR DESCRIPTION
### 📊 Metadata *

Command injection vulnerability 
#### Bounty URL: https://www.huntr.dev/bounties/1-npm-node-key-sender

### ⚙️ Description *

`node-key-sender` is a module that sends keyboard events to the operational system, this package is vulnerable to Command Injection. It was using `exec()` function which is vulnerable to **Command Injection** if it accepts user input and it goes through any sanitization or escaping.

### 💻 Technical Description *

The use of the `child_process` function `exec()` is highly discouraged if you accept user input and don't sanitize/escape them. I replaced it with `execFile()` which mitigates any possible Command Injections as it accepts input as arrays.

### 🐛 Proof of Concept (PoC) *

Install the package and run the below code:
```javascript
var root = require("node-key-sender");
var attack_code = ["&touch", "Song"];
root.execute(attack_code);
```
![before](https://user-images.githubusercontent.com/16708391/91081494-dac9d580-e664-11ea-90ca-47043f237ff5.JPG)


### 🔥 Proof of Fix (PoF) *

After applying the fix, run the PoC again and no files will be created. Hence command injection is mitigated.

![after](https://user-images.githubusercontent.com/16708391/91081638-0fd62800-e665-11ea-83e1-8bcea5fb4cd7.JPG)


### 👍 User Acceptance Testing (UAT)

Only `execFile` is used, no breaking changes introduced.
