### PR TITLE
[FIX] RCE through execFile()

### DIFF
--- a/key-sender.js
+++ b/key-sender.js
@@ -119,7 +119,6 @@ module.exports = function() {
                     resolve(stdout, stderr);
                 } else {
                     reject(error, stdout, stderr);
-                    console.log('err')
                 }
             });
         });

--- a/key-sender.js
+++ b/key-sender.js
@@ -1,4 +1,4 @@
-var exec = require('child_process').exec;
+var execFile = require('child_process').execFile;
 var path = require("path");
 
 module.exports = function() {
@@ -112,13 +112,14 @@ module.exports = function() {
         return new Promise(function(resolve, reject) {
             var jarPath = path.join(__dirname, 'jar', 'key-sender.jar');
 
-            var command = 'java -jar \"' + jarPath + '\" ' + arrParams.join(' ') + module.getCommandLineOptions();
+            var command = ('java -jar ' + jarPath + ' ' + arrParams.join(' ') + module.getCommandLineOptions()).split(' ');
 
-            return exec(command, {}, function(error, stdout, stderr) {
+            return execFile(command[0], command.slice(1), function(error, stdout, stderr) {
                 if (error == null) {
                     resolve(stdout, stderr);
                 } else {
                     reject(error, stdout, stderr);
+                    console.log('err')
                 }
             });
         });


### PR DESCRIPTION
#### Bounty URL: https://www.huntr.dev/bounties/1-npm-node-key-sender

### ⚙️ Description *

The `key-sender.js` file was vulnerable against `RCE` which happened because some `user-supplied` inputs were unsafely concatenated and `executed` as commands, leading to `arbitrary command injection`.

### 💻 Technical Description *

I simply used the `execFile()` function in order to avoid the `inputs` concatenated could be injected as `commands` and then be executed and lead to `RCE`.

### 🐛 Proof of Concept (PoC) *

1. Create the `poc.js` file:
```js
var test = require("./");
var attack_code = ["&touch", "Song"];
test.execute(attack_code);
```
2. `node poc.js`
3. The file `Song` is created

![Screenshot from 2020-08-24 17-53-02](https://user-images.githubusercontent.com/33063403/91082645-3a19ec80-e649-11ea-8fb6-4d0c09446d42.png)

### 🔥 Proof of Fix (PoF) *

Use the fixed version for the same steps of above ... no `Song` file is created :smile:

![Screenshot from 2020-08-24 20-30-21](https://user-images.githubusercontent.com/33063403/91082558-2078a500-e649-11ea-86e6-7d96dbbd8a7c.png)

### 👍 User Acceptance Testing (UAT)

All OK, just replaced `exec()` with `execFile()` and deleted the `"` from the `jarPath` since `execFile()` interpreted them as part of the path leading to errors :+1: 